### PR TITLE
Add GitHub issue buttons to Emul8Me website

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -20,7 +20,11 @@
             <h3 style="color: #ff7b00;">Please note, this website is still under development, and more games will be added over time.</h3>
         </section>
         <section>
-           You can contact me by email on <a href="mailto:Emul8Me@opott.is-cool.me">Emul8Me@opott.is-cool.me</a>.
+            <h2>Open a GitHub Issue</h2>
+            <a class="gitissue" style="color: white; background-color: #ff6100; padding: 20px; text-decoration: none;" href="https://github.com/opott/Emul8Me/issues/new?assignees=opott&labels=Bug&projects=&template=bug-report.md&title=%5BBug%5D+Description">Bug Report</a>
+            <a class="gitissue" style="color: white; background-color: #ff6100; padding: 20px; text-decoration: none;" href="https://github.com/opott/Emul8Me/issues/new?assignees=opott&labels=Cover+Art+Improvement&projects=&template=cover-art-improvement.md&title=%5BSYSTEM%5D+Game+Name">Cover Art Improvement</a>
+            <a class="gitissue" style="color: white; background-color: #ff6100; padding: 20px; text-decoration: none;" href="https://github.com/opott/Emul8Me/issues/new?assignees=opott&labels=New+Game+Request&projects=&template=game-request.md&title=%5BSYSTEM%5D+Game+Title">Game Request</a>
+            <a class="gitissue" style="color: white; background-color: #ff6100; padding: 20px; text-decoration: none;" href="https://github.com/opott/Emul8Me/issues/new">Other</a>
         </section>
     </main>
     
@@ -28,4 +32,15 @@
         <p>&copy; 2024 Emul8Me. All rights reserved.</p>
     </footer>
 </body>
+<style>
+    gitissue {
+        background-color: #ff6100;
+        color: #ff6100;
+        padding: 14px 20px;
+        margin: 8px 0;
+        border: none;
+        cursor: pointer;
+        width: 100%;
+    }
+</style>
 </html>


### PR DESCRIPTION
This pull request adds GitHub issue buttons to the Emul8Me website, allowing users to easily report bugs, request game improvements, or make other types of requests.