### PR TITLE
Fix SNES cover art sizes

### DIFF
--- a/snes.html
+++ b/snes.html
@@ -32,4 +32,10 @@
         <p>&copy; 2024 Emul8Me. All rights reserved.</p>
     </footer>
 </body>
+<style>
+    img {
+        width: 400px;
+        height: 250px;
+    }
+</style>
 </html>


### PR DESCRIPTION
This pull request fixes the sizes of the SNES cover art images. Previously, the images were not displaying correctly due to incorrect width and height values. This PR adds a CSS style to set the width to 400px and height to 250px for the images, ensuring they are displayed properly.